### PR TITLE
Add explicit imports in every test file to work around missing types complaints in IDE

### DIFF
--- a/src/qyu.spec.ts
+++ b/src/qyu.spec.ts
@@ -1,3 +1,5 @@
+import 'chai-as-promised';
+import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { Qyu, QyuError } from './index.js';

--- a/tests/qyu.test.ts
+++ b/tests/qyu.test.ts
@@ -1,3 +1,5 @@
+import 'chai-as-promised';
+import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { Qyu } from '../src/index.js';


### PR DESCRIPTION
Add explicit imports in every test file to work around VS Code that's unable to recognize types like `describe` and `it` and others... 🤞🏻