### PR TITLE
Revert last merged change to minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/shtaif/Qyu/issues",
   "engineStrict": true,
   "engines": {
-    "node": ">=10.24"
+    "node": ">=7.6.0"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Revert last merged change to minimum node version order to commit it again properly marked as breaking change.