### PR TITLE
bump minimum node version requirement to `>=10.24` for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/shtaif/Qyu/issues",
   "engineStrict": true,
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=10.24"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Bump package's minimum node version requirement from `>=7.6.0` to `>=10.24` for now.